### PR TITLE
Fixes "not an array" error

### DIFF
--- a/application/controllers/compare.php
+++ b/application/controllers/compare.php
@@ -36,8 +36,8 @@ class Compare extends MY_Controller
         /**
          * Create/Drop any tables that are not in the Live database
          */
-        $sql_commands_to_run = (is_array($tables_to_create) && !empty($tables_to_create)) ? array_merge($sql_commands_to_run, $this->manage_tables($tables_to_create, 'create')) : '';
-        $sql_commands_to_run = (is_array($tables_to_drop) && !empty($tables_to_drop)) ? array_merge($sql_commands_to_run, $this->manage_tables($tables_to_drop, 'drop')) : '';
+        $sql_commands_to_run = (is_array($tables_to_create) && !empty($tables_to_create)) ? array_merge($sql_commands_to_run, $this->manage_tables($tables_to_create, 'create')) : array();
+        $sql_commands_to_run = (is_array($tables_to_drop) && !empty($tables_to_drop)) ? array_merge($sql_commands_to_run, $this->manage_tables($tables_to_drop, 'drop')) : array();
 
         $tables_to_update = $this->compare_table_structures($development_tables, $live_tables);
 


### PR DESCRIPTION
Fixes "Message: array_merge() [function.array-merge]: Argument #1 is not an array" error when there are no tables to CREATE or DROP