### PR TITLE
Removed CHARACTER SET on MODIFY and ADD

### DIFF
--- a/application/controllers/compare.php
+++ b/application/controllers/compare.php
@@ -260,8 +260,7 @@ class Compare extends MY_Controller
                             {
                                 // ALTER TABLE `bugs` MODIFY COLUMN `site_name`  varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL AFTER `type`;
                                 // ALTER TABLE `bugs` MODIFY COLUMN `message`  varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL AFTER `site_name`;
-                                $modify_field = "ALTER TABLE $table MODIFY COLUMN " . $fields[$n]["Field"] . ' ' . $fields[$n]["Type"] . ' CHARACTER SET ' . $this->CHARACTER_SET;
-                                $modify_field .= (isset($fields[$n]["Default"]) && $fields[$n]["Default"] != '') ? ' DEFAULT \'' . $fields[$n]["Default"] . '\'' : '';
+                                $modify_field = "ALTER TABLE $table MODIFY COLUMN " . $fields[$n]["Field"] . ' ' . $fields[$n]["Type"];
                                 $modify_field .= (isset($fields[$n]["Extra"]) && $fields[$n]["Extra"] != '') ? ' ' . $fields[$n]["Extra"] : '';
                                 $modify_field .= (isset($previous_field) && $previous_field != '') ? ' AFTER ' . $previous_field : '';
                                 $modify_field .= ';';
@@ -278,9 +277,8 @@ class Compare extends MY_Controller
                     /*
                      * Add 
                      */
-                    $add_field = "ALTER TABLE $table ADD COLUMN " . $field["Field"] . " " . $field["Type"] . " CHARACTER SET " . $this->CHARACTER_SET;
-                    $add_field .= (isset($field["Null"]) && $field["Null"] == 'YES') ? ' Null' : '';
-                    $add_field .= " DEFAULT " . $field["Default"];
+                    $add_field = "ALTER TABLE $table ADD COLUMN " . $field["Field"] . " " . $field["Type"];
+                    $add_field .= (isset($field["NULL"]) && $field["NULL"] == 'YES') ? ' NULL' : '';
                     $add_field .= (isset($field["Extra"]) && $field["Extra"] != '') ? ' ' . $field["Extra"] : '';
                     $add_field .= ';';
                     $sql_commands_to_run[] = $add_field;


### PR DESCRIPTION
The CHARACTER SET on MODIFY AND ADD would throw an error when running the query in SQL - I don't believe you can set / convert the character set when modifying or adding a column